### PR TITLE
Add replay_runs.py and --testing option for reduction_agent.py

### DIFF
--- a/cms_agents/reduction_agent.py
+++ b/cms_agents/reduction_agent.py
@@ -133,7 +133,7 @@ def get_args():
         "--testing",
         default=False,
         action="store_true",
-        help="reduction_agent will not generate output"
+        help="reduction_agent will send output only to the console"
     )
 
     return parser.parse_args()

--- a/cms_agents/reduction_agent.py
+++ b/cms_agents/reduction_agent.py
@@ -65,14 +65,14 @@ def publish_reduced_documents(reduced, metadata, reduced_publisher):
     reduced_publisher("stop", cr.compose_stop())
 
 
-def respond_to_stop_with_reduced(consumer_topic, testing):
+def respond_to_stop_with_reduced(consumer_topic: str, testing: bool = False):
 
     kafka_config = nslsii.kafka_utils._read_bluesky_kafka_config_file(config_file_path="/etc/bluesky/kafka.yml")
 
     cms_tiled_client = from_profile("cms")
     
     if testing:
-        def do_both(name, doc):
+        def output_reduced_document(name, doc):
             print(
                 f"{datetime.datetime.now().isoformat()} output document: {name}\n"
                 f"contents: {pprint.pformat(doc)}\n"
@@ -86,7 +86,7 @@ def respond_to_stop_with_reduced(consumer_topic, testing):
             producer_config=kafka_config["runengine_producer_config"],
         )
 
-        def do_both(name, doc):
+        def output_reduced_document(name, doc):
             cms_sandbox_tiled_client.v1.insert(name, doc)
             reduced_publisher(name, doc)
 
@@ -101,7 +101,7 @@ def respond_to_stop_with_reduced(consumer_topic, testing):
             print(f"found run_start id {run_start_id}")
             bluesky_run = cms_tiled_client[run_start_id]
             reduced, metadata = reduce_run(bluesky_run)
-            publish_reduced_documents(reduced, metadata, do_both)
+            publish_reduced_documents(reduced, metadata, output_reduced_document)
         else:
             pass
 

--- a/cms_agents/replay_runs.py
+++ b/cms_agents/replay_runs.py
@@ -1,0 +1,65 @@
+import argparse
+
+from bluesky_kafka import Publisher
+from nslsii.kafka_utils import _read_bluesky_kafka_config_file
+from tiled.client import from_profile
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--produce",
+        default=False,
+        action="store_true", help="set to produce Kafka messsages"
+    )
+
+    return parser.parse_args()
+
+
+def replay_runs(produce):
+    kafka_config = _read_bluesky_kafka_config_file("/etc/bluesky/kafka.yml")
+    bluesky_document_producer = Publisher(
+        topic="cms.test",
+        bootstrap_servers=",".join(kafka_config["bootstrap_servers"]),
+        key="cms-pta-replay-scans",
+        producer_config=kafka_config["runengine_producer_config"],
+    )
+
+    cms_client = from_profile("cms")
+
+    print()
+    if produce:
+        print("replaying runs to topic cms.test")
+    else:
+        print("Kafka messages will not be produced because --produce was not specified on the command line")
+    print()
+    print("enter lists of space-separated scan ids to be replayed")
+    print("enter an empty list to quit")
+    print()
+    while True:
+        try:
+            scan_ids_input = input("scan ids to replay: ")
+            scan_ids = scan_ids_input.split()
+            if len(scan_ids) == 0:
+                print("all done!")
+                break
+            else:
+                for scan_id in scan_ids:
+                    print(f"replaying scan id {scan_id}")
+                    if produce:
+                        for name, document in cms_client[int(scan_id)].documents():
+                            print(f"  producing message with {name} document")
+                            bluesky_document_producer(name, document)
+                        bluesky_document_producer.flush()
+                    else:
+                        print("  no messages produced")
+        except KeyboardInterrupt:
+            print()
+            print("all done!")
+            break
+
+
+if __name__ == "__main__":
+    replay_run_args = get_args()
+    replay_runs(**vars(replay_run_args))


### PR DESCRIPTION
This PR proposes updates to facilitate developing the analysis functionality for `reduction_agent.py`.

A new script `replay_runs.py` is added to produce Kafka messages on topic `cms.test` for specified scan ids:
```
$ python replay_runs.py -h
usage: replay_runs.py [-h] [--produce]

options:
  -h, --help  show this help message and exit
  --produce   set to produce Kafka messsages
```
For example:
```
$ python replay_runs.py --produce
OBJECT CACHE: Will use up to 5_021_838_336 bytes (15% of total physical RAM)

replaying runs to topic cms.test

enter lists of space-separated scan ids to be replayed
enter an empty list to quit

scan ids to replay: 925436
replaying scan id 925436
  producing message with start document
  producing message with descriptor document
  producing message with resource document
  producing message with datum_page document
  producing message with event_page document
  producing message with stop document
scan ids to replay: <ENTER>
all done!
```

A CLI is added to `reduction_agent.py`:
```
$ python reduction_agent.py -h
usage: reduction_agent.py [-h] [--consumer-topic CONSUMER_TOPIC] [--testing]

options:
  -h, --help            show this help message and exit
  --consumer-topic CONSUMER_TOPIC
                        Kafka topic for reduction_agent input
  --testing             reduction_agent will send output only to the console
```

When `--testing` is specified, `reduction_agent.py` will not produce Kafka messages, nor will it insert data directly into tiled. The intention is that during development `reduction-agent.py` runs with these command line arguments:
```
$ python reduction_agent.py --testing --consumer-topic cms.test
```
Updates to `reduction_agent.py` can be tested by replayinig runs:
```
$ python replay_runs.py --produce
OBJECT CACHE: Will use up to 5_021_838_336 bytes (15% of total physical RAM)

replaying runs to topic cms.test

enter lists of space-separated scan ids to be replayed
enter an empty list to quit

scan ids to replay: 925436
replaying scan id 925436
  producing message with start document
  producing message with descriptor document
  producing message with resource document
  producing message with datum_page document
  producing message with event_page document
  producing message with stop document
scan ids to replay:
all done!
```
The `reduction_agent.py` prints this to the console in response to the run with scan id 925436 being replayed:
```
found run_start id bd498774-8948-45de-9fe1-9cc96c2b7b53
give reduced on run <BlueskyRun {'primary'} scan_id=925436 uid='bd498774' 2023-02-07 09:45>
2023-03-09T11:33:09.750760 output document: start
contents: {'raw_start': {'beam_int_bim3': 0.0,
               'beam_int_bim4': 0.0,
               'beam_int_bim5': 0.0,
               'beam_intensity_expected': 20000,
               'beam_size_x_mm': 0.1999979999999999,
               'beam_size_y_mm': 0.049985999999999864,
               'beamline_mode': 'measurement',
               'calibration_energy_keV': 13.5,
               'calibration_wavelength_A': 0.91839,
               'detector_sequence_ID': 0,
               'detectors': ['pilatus2M'],
               'experiment_SAF_number': '301000',
               'experiment_alias_directory': '/nsls2/data/cms/legacy/xf11bm/data/2023_1/beamline/PTA/',
               'experiment_cycle': '2023_1',
               'experiment_group': 'KYager',
               'experiment_project': 'TBD',
               'experiment_proposal_number': '301000',
               'experiment_type': 'SAXS',
               'experiment_user': 'TBD',
               'filename': 'test_Tc116.71_71807.8s_x0.000_th0.120_1.00s_925436',
               'hints': {'dimensions': [[['time'], 'primary']]},
               'measure_type': 'measure',
               'motor_SAXSx': -65.0,
               'motor_SAXSy': -73.00000558,
               'motor_WAXSx': -210.0,
               'motor_WAXSy': 30.0,
               'motor_WAXSz': 0.0,
               'motor_smx': 88.0,
               'motor_smy': 15.63,
               'motor_sth': 1.120000000000001,
               'num_intervals': 0,
               'num_points': 1,
               'plan_args': {'detectors': ["Pilatus2MV33(prefix='XF:11BMB-ES{Det:PIL2M}:', "
                                           "name='pilatus2M', "
                                           "read_attrs=['stats1', "
                                           "'stats1.total', 'stats2', "
                                           "'stats2.total', 'stats3', "
                                           "'stats3.total', 'stats4', "
                                           "'stats4.total', 'tiff'], "
                                           "configuration_attrs=['stats1', "
                                           "'stats2', 'stats3', 'stats4', "
                                           "'tiff'])"],
                             'num': 1},
               'plan_header_override': 'measure',
               'plan_name': 'count',
               'plan_type': 'generator',
               'platform_beam': 45,
               'sample_clock': 71807.77431893349,
               'sample_exposure_time': 1,
               'sample_measurement_ID': 1,
               'sample_motor_th': 1.120000000000001,
               'sample_motor_x': 88.0,
               'sample_motor_y': 15.63,
               'sample_name': 'test',
               'sample_savename': 'test_Tc116.71_71807.8s_x0.000_th0.120_1.00s',
               'sample_savename_extra': None,
               'sample_th': 0.120000000000001,
               'sample_x': 0.0,
               'sample_y': 0.0,
               'scan_id': 925436,
               'time': 1675781103.1242259,
               'uid': 'bd498774-8948-45de-9fe1-9cc96c2b7b53'},
 'time': 1678379589.748345,
 'uid': '001c0c2e-16cf-4485-927d-a413e665ed6a'}

2023-03-09T11:33:09.753387 output document: descriptor
contents: {'configuration': {},
 'data_keys': {'next big thing': {'dtype': 'string',
                                  'shape': [],
                                  'source': 'computed'}},
 'hints': {},
 'name': 'primary',
 'object_keys': {},
 'run_start': '001c0c2e-16cf-4485-927d-a413e665ed6a',
 'time': 1678379589.7526422,
 'uid': '65b5b6a1-8e23-4c5f-ac04-5d3fd5e122f0'}

2023-03-09T11:33:09.753980 output document: event
contents: {'data': {'next big thing': 'avocado toast'},
 'descriptor': '65b5b6a1-8e23-4c5f-ac04-5d3fd5e122f0',
 'filled': {},
 'seq_num': 1,
 'time': 1678379589.7537398,
 'timestamps': {'next big thing': 1678379589.7537057},
 'uid': '97ce56fd-9ca0-431d-b495-286119fa83df'}

2023-03-09T11:33:09.754681 output document: stop
contents: {'exit_status': 'success',
 'num_events': {'primary': 1},
 'reason': '',
 'run_start': '001c0c2e-16cf-4485-927d-a413e665ed6a',
 'time': 1678379589.7542584,
 'uid': 'ba0b2d3b-e673-4b63-a563-156773f910a2'}
```
