### PR TITLE
Two edits to the GPCam agent

### DIFF
--- a/cms_agents/startup_scripts/gpCAM_agent.py
+++ b/cms_agents/startup_scripts/gpCAM_agent.py
@@ -2,7 +2,7 @@ from bluesky_adaptive.server import register_variable, shutdown_decorator, start
 
 from cms_agents.gpcam_agent import CMSgpCAMAgent
 
-agent = CMSgpCAMAgent(report_on_tell=False, ask_on_tell=False)
+agent = CMSgpCAMAgent(report_on_tell=False, ask_on_tell=True)
 
 
 @startup_decorator


### PR DESCRIPTION
Overall looks great. 
1. Registered the acq fun to a property on the server. This exposes it to the user for changes without nuking the agent. 
2. Moved expensive operations to the ask. This way the agent can keep updating its caches while an ask is running. Ask/Tell will happen async, but the internal GPCam calls will not (so an expensive call in Tell will create a backlog from Kafka). 

Let me know if we need to add the variance read into the tell. Should be easy enough with a `variance_cache` to work along side the observable cache. 